### PR TITLE
Propagate ThreadDeath

### DIFF
--- a/sisu-inject/containers/guice-bean/guice-bean-reflect/src/main/java/org/sonatype/guice/bean/reflect/AbstractDeferredClass.java
+++ b/sisu-inject/containers/guice-bean/guice-bean-reflect/src/main/java/org/sonatype/guice/bean/reflect/AbstractDeferredClass.java
@@ -13,6 +13,7 @@ package org.sonatype.guice.bean.reflect;
 
 import javax.inject.Inject;
 
+import com.google.common.base.Throwables;
 import com.google.inject.Injector;
 import com.google.inject.ProvisionException;
 
@@ -48,6 +49,9 @@ abstract class AbstractDeferredClass<T>
         }
         catch ( final Throwable e )
         {
+            for ( Throwable t = e; t != null; t = t.getCause() ) {
+                Throwables.propagateIfInstanceOf( t, ThreadDeath.class );
+            }
             try
             {
                 Logs.warn( "Error injecting: {}", getName(), e );

--- a/sisu-inject/containers/guice-bean/guice-bean-reflect/src/main/java/org/sonatype/guice/bean/reflect/URLClassSpace.java
+++ b/sisu-inject/containers/guice-bean/guice-bean-reflect/src/main/java/org/sonatype/guice/bean/reflect/URLClassSpace.java
@@ -26,6 +26,8 @@ import java.util.jar.JarFile;
 import java.util.jar.JarInputStream;
 import java.util.jar.Manifest;
 
+import com.google.common.base.Throwables;
+
 /**
  * {@link ClassSpace} backed by a strongly-referenced {@link ClassLoader} and a {@link URL} class path.
  */
@@ -102,6 +104,7 @@ public final class URLClassSpace
         }
         catch ( final Throwable e )
         {
+            Throwables.propagateIfInstanceOf( e, ThreadDeath.class );
             throw new TypeNotPresentException( name, e );
         }
     }


### PR DESCRIPTION
While investigating http://netbeans.org/bugzilla/show_bug.cgi?id=201098 I found that if `Thread.stop` is called on a thread inside Sisu/Guice code, rather than immediately stopping, `ThreadDeath` is wrapped and perhaps even cached. The culprit is code which indisciminately catches `Throwable`.

All such code should be reviewed generally - probably you only want to catch checked exceptions, `RuntimeException`, and perhaps selected errors such as `LinkageError` - but proper treatment of `ThreadDeath` is especially important.

Here is a typical stack trace mentioning `AbstractDeferredClass.get`:

```
WARNING [org.sonatype.guice.bean.reflect.NamedClass]: Error injecting: org.apache.maven.artifact.resolver.DefaultResolutionErrorHandler
java.lang.ThreadDeath
    at java.lang.Thread.stop(Thread.java:813)
...stack trace shows caller, not stopped thread...
Caused: com.google.inject.internal.util.$ComputationException
    at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:553)
    at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:419)
    at com.google.inject.internal.util.$CustomConcurrentHashMap$ComputingImpl.get(CustomConcurrentHashMap.java:2041)
    at com.google.inject.internal.FailableCache.get(FailableCache.java:50)
    at com.google.inject.internal.MembersInjectorStore.get(MembersInjectorStore.java:65)
    at com.google.inject.internal.ConstructorInjectorStore.createConstructor(ConstructorInjectorStore.java:73)
    at com.google.inject.internal.ConstructorInjectorStore.access$000(ConstructorInjectorStore.java:28)
    at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:36)
    at com.google.inject.internal.ConstructorInjectorStore$1.create(ConstructorInjectorStore.java:32)
    at com.google.inject.internal.FailableCache$1.apply(FailableCache.java:39)
    at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:549)
Caused: com.google.inject.internal.util.$ComputationException
    at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:553)
    at com.google.inject.internal.util.$MapMaker$StrategyImpl.compute(MapMaker.java:419)
    at com.google.inject.internal.util.$CustomConcurrentHashMap$ComputingImpl.get(CustomConcurrentHashMap.java:2041)
    at com.google.inject.internal.FailableCache.get(FailableCache.java:50)
    at com.google.inject.internal.ConstructorInjectorStore.get(ConstructorInjectorStore.java:49)
    at com.google.inject.internal.ConstructorBindingImpl.initialize(ConstructorBindingImpl.java:125)
    at com.google.inject.internal.InjectorImpl.initializeJitBinding(InjectorImpl.java:520)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBinding(InjectorImpl.java:837)
    at com.google.inject.internal.InjectorImpl.createJustInTimeBindingRecursive(InjectorImpl.java:769)
    at com.google.inject.internal.InjectorImpl.getJustInTimeBinding(InjectorImpl.java:254)
    at com.google.inject.internal.InjectorImpl.getBindingOrThrow(InjectorImpl.java:205)
    at com.google.inject.internal.InjectorImpl.getInternalFactory(InjectorImpl.java:843)
    at com.google.inject.internal.InjectorImpl.getProviderOrThrow(InjectorImpl.java:957)
    at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:990)
    at com.google.inject.internal.InjectorImpl.getProvider(InjectorImpl.java:951)
    at com.google.inject.internal.InjectorImpl.getInstance(InjectorImpl.java:1003)
    at org.sonatype.guice.bean.reflect.AbstractDeferredClass.get(AbstractDeferredClass.java:47)
```

For the other change:

```
Caused: java.lang.TypeNotPresentException: Type org.apache.maven.project.DefaultProjectBuilder not present

    at org.sonatype.guice.bean.reflect.URLClassSpace.loadClass(URLClassSpace.java:100)
```

The stack trace lines in `MapMaker.java` do not exist in actual sources - I guess this is generated somehow. Confirming poor implementation in bytecode:

```
   0:   aload_3
   1:   aload_1
   2:   invokeinterface #243,  2; //InterfaceMethod com/google/inject/internal/util/$Function.apply:(Ljava/lang/Object;)Ljava/lang/Object;
   7:   astore  4
   9:   goto    38
   12:  astore  5
   14:  aload_0
   15:  aload_2
   16:  new #38; //class com/google/inject/internal/util/$MapMaker$ComputationExceptionReference
   19:  dup
   20:  aload   5
   22:  invokespecial   #246; //Method com/google/inject/internal/util/$MapMaker$ComputationExceptionReference."<init>":(Ljava/lang/Throwable;)V
   25:  invokevirtual   #117; //Method setValueReference:(Lcom/google/inject/internal/util/$MapMaker$ReferenceEntry;Lcom/google/inject/internal/util/$MapMaker$ValueReference;)V
   28:  new #248; //class com/google/inject/internal/util/$ComputationException
   31:  dup
   32:  aload   5
   34:  invokespecial   #249; //Method com/google/inject/internal/util/$ComputationException."<init>":(Ljava/lang/Throwable;)V
   37:  athrow
```

Would best be fixed upstream in sisu-guava; the closest source code I could find was:

```
diff --git a/guava/src/com/google/common/collect/ComputingConcurrentHashMap.java b/guava/src/com/google/common/collect/ComputingConcurrentHashMap.java
index 4b1c69a..fda4dcd 100644
--- a/guava/src/com/google/common/collect/ComputingConcurrentHashMap.java
+++ b/guava/src/com/google/common/collect/ComputingConcurrentHashMap.java
@@ -354,6 +354,7 @@ class ComputingConcurrentHashMap<K, V> extends CustomConcurrentHashMap<K, V> {
       try {
         value = computingFunction.apply(key);
       } catch (Throwable t) {
+        Throwables.propagateIfInstanceOf(t, ThreadDeath.class);
         setValueReference(new ComputationExceptionReference<K, V>(t));
         throw new ExecutionException(t);
       }
```
